### PR TITLE
Switch to gcc since clang not properly configured by default on Lion

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -41,7 +41,7 @@
 		</javah>
 	</target>
 	<target name="build-c" depends="build-dest,build-javah">
-		<exec executable="clang" dir="src/c">
+		<exec executable="gcc" dir="src/c">
 		    <arg value="-arch" />
 		    <arg value="i386" />
 		    <arg value="-arch" />
@@ -73,7 +73,7 @@
 		</exec>
 	</target>
 	<target name="codegen-generate_enums-build">
-		<exec executable="clang" dir="src/c/codegen">
+		<exec executable="gcc" dir="src/c/codegen">
 		    <arg value="-arch" />
 		    <arg value="i386" />
 		    <arg value="-arch" />
@@ -89,7 +89,7 @@
 		</exec>
 	</target>
 
-	<target name="dist" depends="build,doc">
+	<target name="dist" depends="build">
 		<mkdir dir="dist" />
 		<jar destfile="dist/osxkeychain.jar" basedir="lib" index="true" />
 		<zip destfile="dist/osxkeychain.zip">


### PR DESCRIPTION
Feel free to reject this since these things can get religious, but clang was for some reason all messed up with the most recent xcode command line tools, causing all sorts of problems with linking. Swiching over to gcc fixed everything.

I also got rid of building the javadocs by default because it takes way longer than building the actual code, and users can just do `ant doc` if they want?
